### PR TITLE
feat: support local auth

### DIFF
--- a/src/litai/client.py
+++ b/src/litai/client.py
@@ -106,11 +106,13 @@ class LLM:
                 "Either provide both or none.\n"
                 "To find the API key and user ID, go to the Global Settings page in your Lightning account."
             )
-        if lightning_api_key is not None:
-            os.environ["LIGHTNING_API_KEY"] = lightning_api_key
 
-        if lightning_user_id is not None:
+        if lightning_api_key is not None and lightning_user_id is not None:
+            os.environ["LIGHTNING_API_KEY"] = lightning_api_key
             os.environ["LIGHTNING_USER_ID"] = lightning_user_id
+
+        if os.environ.get("LIGHTNING_API_KEY") is None and os.environ.get("LIGHTNING_USER_ID") is None:
+            self._authenticate()
 
         if verbose not in [0, 1, 2]:
             raise ValueError("Verbose must be 0, 1, or 2.")
@@ -135,9 +137,7 @@ class LLM:
 
         threading.Thread(target=self._load_models, daemon=True).start()
 
-    def _authenticate(self, lightning_api_key: Optional[str], lightning_user_id: Optional[str]) -> None:
-        if not (lightning_api_key and lightning_user_id):
-            return
+    def _authenticate(self) -> None:
         auth = login.Auth()
         try:
             auth.authenticate()


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Non-studio users can use LitAI. The difference to [this approach](https://github.com/Lightning-AI/litAI/pull/3) is the following:
- when `lightning_api_key` and `lightning_user_id` are given, no further auth
- only when there is no information of the user, this will redirect users to login through the browser (Demo: https://www.loom.com/share/567ce641f624418fb8b8811bb3409139?sid=3512aa8e-11d3-4819-9606-ace8cb6b4e0f)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
