### PR TITLE
Add setup method for Tool's state initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,7 @@ result = llm.call_tool(chosen_tool, tools=[get_weather])
 from litai import LLM, LitTool
 
 class FAQTool(LitTool):
-    def __init__(self):
-        super().__init__()
+    def setup(self):
         self.faq = {
             "pricing": "You can view our pricing plans on the website.",
             "support": "Our support team is available 24/7 via chat.",

--- a/src/litai/tools.py
+++ b/src/litai/tools.py
@@ -35,6 +35,11 @@ class LitTool(BaseModel):
             cls.description = cls.run.__doc__.strip()
 
         cls.name = "".join(["_" + c.lower() if c.isupper() else c for c in cls.__name__]).lstrip("_")
+        cls.setup(cls)
+
+    def setup(self) -> None:
+        """Use this method to store states."""
+        pass
 
     def run(self, *args: Any, **kwargs: Any) -> Any:
         """Run the tool."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -171,3 +171,14 @@ def test_decorator_with_parentheses():
     assert schema["parameters"]["properties"]["detailed"]["type"] == "bool"
     assert schema["parameters"]["required"] == ["service"]
     assert isinstance(get_status, LitTool)
+
+
+def test_tool_setup():
+    class TestTool(LitTool):
+        def setup(self) -> None:
+            self.state = 1
+
+    tool_instance = TestTool()
+    assert tool_instance.state == 1, "State initialized with 1"
+    tool_instance.state += 1
+    assert tool_instance.state == 2, "State not incremented. Should be 2"


### PR DESCRIPTION
- Changed the constructor of FAQTool to use a setup method for initialization.
- Added a setup method to LitTool for state management.
- Introduced a test for the setup method to ensure state initialization works correctly.

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
