### PR TITLE
fix the `auto_call_tools` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ print("Sentiment:", sentiment)
 ```
 
 ### Tools ([docs](https://lightning.ai/docs/litai/features/tools))
-Tools allow models to get real-world data or take actions. In LitAI, there is no magic with tool use, agents can decide to call tools (`auto_tool_calls=True`), or you can manually call a tool with `llm.call_tool(...)` for full control. Zero magic, just plain Python.
+Tools allow models to get real-world data or take actions. In LitAI, there is no magic with tool use, agents can decide to call tools (`auto_call_tools=True`), or you can manually call a tool with `llm.call_tool(...)` for full control. Zero magic, just plain Python.
 
 ```python
 from litai import LLM, tool
@@ -144,7 +144,7 @@ def get_weather(location: str):
 
 llm = LLM(model="openai/gpt-4")
 
-result = llm.chat("What's the weather in Tokyo?", tools=[get_weather], auto_tool_calls=True)
+result = llm.chat("What's the weather in Tokyo?", tools=[get_weather], auto_call_tools=True)
 # The weather in Tokyo is sunny
 
 chosen_tool = llm.chat("What's the weather in Tokyo?", tools=[get_weather])
@@ -152,7 +152,7 @@ result = llm.call_tool(chosen_tool, tools=[get_weather])
 # The weather in London is sunny
 ```
 
-Choose automatic or manual tool calling based on production needs. `auto_tool_calls=True` is great for quick demos, but can obscure when and why a tool runs which can lead to surprises in production. `llm.call_tool(...)` gives you full control to decide when tools execute, making it easier to log, debug, test, and audit. This clarity is critical for reliability, safety, and trust in real-world systems.
+Choose automatic or manual tool calling based on production needs. `auto_call_tools=True` is great for quick demos, but can obscure when and why a tool runs which can lead to surprises in production. `llm.call_tool(...)` gives you full control to decide when tools execute, making it easier to log, debug, test, and audit. This clarity is critical for reliability, safety, and trust in real-world systems.
 
 <br/>
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

The code uses `auto_call_tools` but README says `auto_tool_calls`. This PR fixes the README code argument for automatic code execution. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
