### PR TITLE
LitTool.from_model method to create LitTool from Pydantic

### DIFF
--- a/src/litai/tools.py
+++ b/src/litai/tools.py
@@ -118,6 +118,24 @@ class LitTool(BaseModel):
         return LangchainTool()
 
     @classmethod
+    def from_model(cls, model: type[BaseModel]) -> "LitTool":
+        """Create a LitTool that exposes a Pydantic model as a structured schema."""
+        class ModelTool(LitTool):
+            def setup(self) -> None:
+                super().setup()
+                self.name = model.__name__
+                self.description = model.__doc__ or ""
+    
+            def run(self, *args, **kwargs) -> Any:
+                # Default implementation: validate & return an instance
+                return model(*args, **kwargs)
+    
+            def _extract_parameters(self) -> Dict[str, Any]:
+                return model.model_json_schema()
+    
+        return ModelTool()
+
+    @classmethod
     def convert_tools(cls, tools: Optional[Sequence[Union["LitTool", "StructuredTool"]]]) -> List["LitTool"]:
         """Convert a list of tools into LitTool instances.
 


### PR DESCRIPTION
This PR adds a class method 'from_model' to create a `LitTool` from a Pydantic model, including setup and run methods for validation.

> In full transparency, I don't know that this is the "best" way to accomplish the task at hand, but certainly consider it as one proposal.


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [X] Did you write any new necessary tests?

</details>

## What does this PR do?

Adds a convenience method which allows converting existing classes which inherit from `pydantic.BaseModel` into `LitTool` classes.

> Why is this useful?
A lot of use cases stop short of true function calling and really just require schema enforcement (e.g., named entity extraction). This method helps create "tools" which do not actually have a function associated with them.

Example:
```python
# pip install litai
import os
import json

from litai import LLM, LitTool
from pydantic import BaseModel
from typing import Literal

class RelationshipNode(BaseModel):
    source_entity: str
    target_entity: str
    relation: Literal["consumer", "producer", "partner"]

get_relationship = LitTool.from_model(RelationshipNode)

llm = LLM(
    model="google/gemini-2.5-flash",
    api_key=os.environ.get("LITAI_API_KEY"),
    max_retries=1,
)

response = llm.chat("Michael purchased credits from Lightning AI", tools=[get_relationship], system_prompt=None)
print(response)

# validate that tool can be called
if "function" not in response:
    raise AssertionError("No function call found in response")
# if available, proceed to check ability to call tool (not necessary in practice, just demonstrates compatibility)
result = llm.call_tool(response, tools=[get_relationship])
print(result)
```

```bash
python ../from_model.py
[{"function": {"arguments": "{\"target_entity\":\"Lightning AI\",\"source_entity\":\"Michael\",\"relation\":\"consumer\"}", "name": "RelationshipNode"}}]
source_entity='Michael' target_entity='Lightning AI' relation='consumer'
```
## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

yes!
