### PR TITLE
fix: remove default max token

### DIFF
--- a/src/litai/llm.py
+++ b/src/litai/llm.py
@@ -210,7 +210,7 @@ class LLM:
         model: SDKLLM,
         prompt: str,
         system_prompt: Optional[str],
-        max_completion_tokens: int,
+        max_completion_tokens: Optional[int],
         images: Optional[Union[List[str], str]],
         conversation: Optional[str],
         metadata: Optional[Dict[str, str]],
@@ -272,7 +272,7 @@ class LLM:
         prompt: str,
         system_prompt: Optional[str] = None,
         model: Optional[str] = None,
-        max_tokens: int = 500,
+        max_tokens: Optional[int] = None,
         images: Optional[Union[List[str], str]] = None,
         conversation: Optional[str] = None,
         metadata: Optional[Dict[str, str]] = None,
@@ -287,7 +287,7 @@ class LLM:
             prompt (str): The message to send to the LLM.
             system_prompt (str): The system prompt to set the context. Defaults to assistant's default system prompt.
             model (Optional[str]): The model to override. If provided, this model will be prioritized and used.
-            max_tokens (int): The maximum number of tokens for the response. Defaults to 500.
+            max_tokens (int): The maximum number of tokens for the response. Defaults to None.
             images (Optional[Union[List[str], str]]): List of local or public image paths to pass to the model.
             conversation (Optional[str]): The conversation ID for maintaining context. Defaults to None.
             metadata (Optional[dict[str, str]]): Dictionary for storing additional information of the request.

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -124,7 +124,7 @@ def test_llm_chat(mock_llm_class):
     mock_llm_instance.chat.assert_called_once_with(
         prompt="Hello, who are you?",
         system_prompt="You are a helpful assistant.",
-        max_completion_tokens=500,
+        max_completion_tokens=None,
         images=None,
         conversation=None,
         metadata={"user_api": "123456"},
@@ -181,7 +181,7 @@ def test_model_override(monkeypatch):
     mock_override.chat.assert_called_once_with(
         prompt="Hello",
         system_prompt=None,
-        max_completion_tokens=500,
+        max_completion_tokens=None,
         images=None,
         conversation=None,
         metadata=None,
@@ -231,7 +231,7 @@ def test_fallback_models(monkeypatch):
     mock_fallback_model.chat.assert_called_with(
         prompt="Hello",
         system_prompt=None,
-        max_completion_tokens=500,
+        max_completion_tokens=None,
         images=None,
         conversation=None,
         metadata=None,


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

With google gemini models, if `max_tokens` is set too low, it may result in an empty response. To make it more reliable, this PR removes the default `max_tokens` value.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
