### PR TITLE
chore: remove deprecated LightningLLM class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,8 @@ setup(
     install_requires=_load_requirements(),
     extras_require=_prepare_extras(),
     project_urls={
-        "Bug Tracker": "https://github.com/Lightning-AI/LightningLLM/issues",
-        "Documentation": "https://lightning-ai.github.io/LightningLLM/",
-        "Source Code": "https://github.com/Lightning-AI/LightningLLM",
+        "Bug Tracker": "https://github.com/Lightning-AI/litAI/issues",
+        "Source Code": "https://github.com/Lightning-AI/litAI",
     },
     classifiers=[
         "Environment :: Console",

--- a/src/litai/__init__.py
+++ b/src/litai/__init__.py
@@ -14,8 +14,8 @@
 """Chat with LLMs through Lightning."""
 
 from litai.__about__ import *  # noqa: F401, F403
-from litai.llm import LLM, LightningLLM  # noqa: F401
+from litai.llm import LLM  # noqa: F401
 from litai.llm_config import Models
 from litai.tools import LitTool, tool
 
-__all__ = ["LLM", "Models", "LitTool", "tool", "LightningLLM"]
+__all__ = ["LLM", "Models", "LitTool", "tool"]

--- a/src/litai/llm.py
+++ b/src/litai/llm.py
@@ -530,16 +530,3 @@ class LLM:
             str: A string representation of the instance.
         """
         return f"<LLM model={self.model} fallback_models={self.fallback_models} max_retries={self.max_retries}"
-
-
-class LightningLLM(LLM):
-    """Alias for the LightningLLM class."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initializes the LightningLLM client."""
-        super().__init__(*args, **kwargs)
-        warnings.warn(
-            "The LightningLLM class is deprecated. Use the LLM class instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-"""LightningLLM tests."""
+"""LitAI tests."""
 # Copyright The Lightning AI team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Removes deprecated `LightningLLM` class. Also removes without replacing the following line, as `https://lightning-ai.github.io/litAI/` does not exist. Let me know if I should replace with different URL.
```diff
- "Documentation": "https://lightning-ai.github.io/LightningLLM/",
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
