### PR TITLE
feat: allow to pass "none" as reasoning effort

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-lightning_sdk >= 2025.09.11
+lightning_sdk >= 2025.09.16

--- a/src/litai/llm.py
+++ b/src/litai/llm.py
@@ -269,7 +269,7 @@ class LLM:
         stream: bool = False,
         tools: Optional[Sequence[Union[LitTool, "StructuredTool"]]] = None,
         auto_call_tools: bool = False,
-        reasoning_effort: Optional[Literal["low", "medium", "high"]] = None,
+        reasoning_effort: Optional[Literal["none", "low", "medium", "high"]] = None,
         **kwargs: Any,
     ) -> str:
         """Sends a message to the LLM and retrieves a response.
@@ -290,13 +290,14 @@ class LLM:
             categorized by conversation ID.
             full_response (bool): Whether the entire response should be returned from the chat.
             auto_call_tools (bool): Tools will be executed automatically whenever applicable. Defaults to False.
-            reasoning_effort (Optional[Literal["low", "medium", "high"]]): The level of reasoning effort for the model.
+            reasoning_effort (Optional[Literal["none", "low", "medium", "high"]]):
+                The level of reasoning effort for the model.
             **kwargs (Any): Additional keyword arguments
 
         Returns:
             str: The response from the LLM.
         """
-        if reasoning_effort is not None and reasoning_effort not in ["low", "medium", "high"]:
+        if reasoning_effort is not None and reasoning_effort not in ["none", "low", "medium", "high"]:
             raise ValueError("reasoning_effort must be 'low', 'medium', 'high', or None")
         self._wait_for_model()
         lit_tools = LitTool.convert_tools(tools)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -119,6 +119,7 @@ def test_llm_chat(mock_llm_class):
         system_prompt="You are a helpful assistant.",
         metadata={"user_api": "123456"},
         my_kwarg="test-kwarg",
+        reasoning_effort="none",
     )
 
     assert isinstance(response, str)
@@ -134,7 +135,7 @@ def test_llm_chat(mock_llm_class):
         full_response=False,
         my_kwarg="test-kwarg",
         tools=None,
-        reasoning_effort=None,
+        reasoning_effort="none",
     )
     test_kwargs = mock_llm_instance.chat.call_args.kwargs
     assert test_kwargs.get("my_kwarg") == "test-kwarg"


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

allows to set reasoning effort to node so it can be turned of on gemini models

```
from litai import LLM 

llm = LLM(model='google/gemini-2.5-flash-lite-preview-06-17')

response = llm.chat("think about energy",  max_tokens=1, reasoning_effort='none')
print(response)

```

response

```
Energy
```


Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
