### PR TITLE
Remove deprecated pkg_resources dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
-from pkg_resources import parse_requirements
 from setuptools import find_packages, setup
 
 _PATH_ROOT = os.path.dirname(__file__)
@@ -20,8 +19,8 @@ def _load_py_module(fname, pkg="litai"):
 
 
 def _load_requirements(path_dir: str = _PATH_ROOT, file_name: str = "requirements.txt") -> list:
-    reqs = parse_requirements(open(os.path.join(path_dir, file_name)).readlines())
-    return list(map(str, reqs))
+    with open(os.path.join(path_dir, file_name)) as f:
+        return [line.split("#")[0].strip() for line in f if line.strip() and not line.startswith("#")]
 
 
 about = _load_py_module("__about__.py")


### PR DESCRIPTION
## What does this PR do?

Removes the deprecated `pkg_resources` dependency from setup.py which was removed in setuptools>=82.

## Did you have fun?

Yes! 🙃